### PR TITLE
Expanding the filename and adding to the list correctly

### DIFF
--- a/lsp-java-lombok.el
+++ b/lsp-java-lombok.el
@@ -52,8 +52,9 @@
 (defun lsp-java-lombok/append-vmargs ()
   "Apply lombok args to lsp-java-vmargs."
   (setq lsp-java-vmargs
-        (append lsp-java-vmargs
-                (concat "-javaagent:" (lsp-java-lombok/jar-path)))))
+        (append
+         lsp-java-vmargs
+         (list (concat "-javaagent:" (expand-file-name (lsp-java-lombok/jar-path)))))))
 
 (defun lsp-java-lombok/setup ()
   "Download Lombok if it hasn't been downloaded already."

--- a/test.el
+++ b/test.el
@@ -19,3 +19,13 @@
                            (should (equal src "https://test.com/lombok-1.0.jar"))
                            (should (equal dest "/test/path/lombok-1.0.jar")))
             (lsp-java-lombok/download-jar))))
+
+(ert-deftest lsp-java-lombok/append-vmargs-in-home-dir ()
+  "VM arg for Lombok is added correctly and resolving the path."
+  (setq-local lsp-java-vmargs '(foo))
+  (setq-local user-emacs-directory "~/test/lombok/")
+  (lsp-java-lombok/append-vmargs)
+  (should (equal
+           lsp-java-vmargs
+           (list 'foo (concat "-javaagent:" (getenv "HOME") "/test/lombok/lombok.jar"))))
+  )


### PR DESCRIPTION
Before this change, a path like "~/user/.emacs.d" caused problems with
LSP, because it did not like the tilde in the path. Now the path is
expanded.

This also fixes the call to `append`, which was previously creating a
single cons cell, where the `-javaagent` was the `cdr`. Now the `cdr`
is correctly a list, with this as a new argument.